### PR TITLE
Persist cart after refresh

### DIFF
--- a/context/cart.tsx
+++ b/context/cart.tsx
@@ -16,6 +16,7 @@ const CartContext = createContext<CartContextType | undefined>(undefined);
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
     const [cart, setCart] = useState<ProductAddCart[]>([]);
+    const [initialized, setInitialized] = useState(false);
     const total = cart.reduce((acc, product) => acc + product.price * product.quantity, 0);
 
     useEffect(() => {
@@ -27,11 +28,14 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
                 console.error('Error parsing cart from localStorage', err);
             }
         }
+        setInitialized(true);
     }, []);
 
     useEffect(() => {
-        localStorage.setItem('cart', JSON.stringify(cart));
-    }, [cart]);
+        if (initialized) {
+            localStorage.setItem('cart', JSON.stringify(cart));
+        }
+    }, [cart, initialized]);
 
     const addToCart = (product: ProductAddCart) => {
         setCart((prevCart) => {

--- a/context/cart.tsx
+++ b/context/cart.tsx
@@ -15,19 +15,20 @@ interface CartContextType {
 const CartContext = createContext<CartContextType | undefined>(undefined);
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
-    const [cart, setCart] = useState<ProductAddCart[]>([]);
-    const total = cart.reduce((acc, product) => acc + product.price * product.quantity, 0);
-
-    useEffect(() => {
-        const storedCart = localStorage.getItem('cart');
-        if (storedCart) {
-            try {
-                setCart(JSON.parse(storedCart));
-            } catch (err) {
-                console.error('Error parsing cart from localStorage', err);
+    const [cart, setCart] = useState<ProductAddCart[]>(() => {
+        if (typeof window !== 'undefined') {
+            const storedCart = localStorage.getItem('cart');
+            if (storedCart) {
+                try {
+                    return JSON.parse(storedCart) as ProductAddCart[];
+                } catch (err) {
+                    console.error('Error parsing cart from localStorage', err);
+                }
             }
         }
-    }, []);
+        return [];
+    });
+    const total = cart.reduce((acc, product) => acc + product.price * product.quantity, 0);
 
     useEffect(() => {
         localStorage.setItem('cart', JSON.stringify(cart));

--- a/context/cart.tsx
+++ b/context/cart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { ProductAddCart } from '@/lib/types';
 
 interface CartContextType {
@@ -17,6 +17,21 @@ const CartContext = createContext<CartContextType | undefined>(undefined);
 export const CartProvider = ({ children }: { children: ReactNode }) => {
     const [cart, setCart] = useState<ProductAddCart[]>([]);
     const total = cart.reduce((acc, product) => acc + product.price * product.quantity, 0);
+
+    useEffect(() => {
+        const storedCart = localStorage.getItem('cart');
+        if (storedCart) {
+            try {
+                setCart(JSON.parse(storedCart));
+            } catch (err) {
+                console.error('Error parsing cart from localStorage', err);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        localStorage.setItem('cart', JSON.stringify(cart));
+    }, [cart]);
 
     const addToCart = (product: ProductAddCart) => {
         setCart((prevCart) => {

--- a/context/cart.tsx
+++ b/context/cart.tsx
@@ -15,20 +15,19 @@ interface CartContextType {
 const CartContext = createContext<CartContextType | undefined>(undefined);
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
-    const [cart, setCart] = useState<ProductAddCart[]>(() => {
-        if (typeof window !== 'undefined') {
-            const storedCart = localStorage.getItem('cart');
-            if (storedCart) {
-                try {
-                    return JSON.parse(storedCart) as ProductAddCart[];
-                } catch (err) {
-                    console.error('Error parsing cart from localStorage', err);
-                }
+    const [cart, setCart] = useState<ProductAddCart[]>([]);
+    const total = cart.reduce((acc, product) => acc + product.price * product.quantity, 0);
+
+    useEffect(() => {
+        const storedCart = localStorage.getItem('cart');
+        if (storedCart) {
+            try {
+                setCart(JSON.parse(storedCart) as ProductAddCart[]);
+            } catch (err) {
+                console.error('Error parsing cart from localStorage', err);
             }
         }
-        return [];
-    });
-    const total = cart.reduce((acc, product) => acc + product.price * product.quantity, 0);
+    }, []);
 
     useEffect(() => {
         localStorage.setItem('cart', JSON.stringify(cart));


### PR DESCRIPTION
## Summary
- add `useEffect` hooks in `CartProvider` to restore the cart from `localStorage` on mount and save it whenever the cart changes

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68606bb1eb488332be25936dbad00bbc